### PR TITLE
Remove `qiskit-terra` dependency in favor of `qiskit`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,4 +31,4 @@ Homepage = "https://github.com/westoun/quasim"
 Issues = "https://github.com/westoun/quasim/issues"
 
 [project.optional-dependencies]
-benchmark = ["qiskit==0.45.1", "qiskit-aer==0.13.1", "qiskit-terra==0.45.1", "scipy==1.13.0"]
+benchmark = ["qiskit==0.45.1", "qiskit-aer==0.13.1", "scipy==1.13.0"]


### PR DESCRIPTION
There is no need to depend on both `qiskit` and `qiskit-terra`. Depending on `qiskit` is more correct, specially towards a possible transition to coming Qiskit releases.

BTW, Qiskit 0.* is reaching EoL. From https://github.com/Qiskit/qiskit/tree/stable/0.46?tab=readme-ov-file#qiskit:

> [!IMPORTANT]
> **The package `qiskit-terra` is not going to be updated after August 15th, 2024**. Since Qiskit 0.44 (released on July 27th, 2023), the `qiskit` meta-package only contains `qiskit-terra`. In Qiskit 1.0 and beyond, the meta-package architecture is removed.
> If you are installing or depending on `qiskit-terra`, consider changing that to `qiskit`: Either `qiskit>=0.x,<1` (if you did not transition to Qiskit 1.0 yet) or `qiskit>=0.x,<2` (to also include Qiskit 1.*).
> [Read more](https://docs.quantum.ibm.com/api/migration-guides/qiskit-1.0-installation#the-old-qiskit-structure).
